### PR TITLE
Fix a travis compilation error

### DIFF
--- a/src/main/scala-2.12/com/linagora/gatling/imap/protocol/command/AppendHandler.scala
+++ b/src/main/scala-2.12/com/linagora/gatling/imap/protocol/command/AppendHandler.scala
@@ -28,7 +28,7 @@ class AppendHandler(session: IMAPSession, tag: Tag) extends BaseActor {
 
   private[this] def doOnMessageForContent(content: String): (IMAPSession, IMAPResponse) => Unit = (session, response) => {
     if (response.isContinuation) {
-      content.lines.foreach(executeTextCommand(session))
+      content.linesIterator.foreach(executeTextCommand(session))
     }
   }
 
@@ -38,7 +38,7 @@ class AppendHandler(session: IMAPSession, tag: Tag) extends BaseActor {
 
       val listener = new RespondToActorIMAPCommandListener(self, userId, Response.Appended, doOnMessage = doOnMessageForContent(content))(logger)
       val flagsAsString = flags.map(_.mkString("(", " ", ")")).getOrElse("()")
-      val length = content.length + content.lines.length - 1
+      val length = content.length + content.linesIterator.length - 1
       logger.debug(s"APPEND receive from sender ${sender.path} on ${self.path}")
       context.become(waitCallback(sender()))
       Try(session.executeAppendCommand(tag.string, mailbox, flagsAsString, length.toString, listener)) match {


### PR DESCRIPTION
```
error] /home/travis/.sbt/1.0/staging/05cb89211ea66aea052a/gatling-imap/src/main/scala-2.12/com/linagora/gatling/imap/protocol/command/AppendHandler.scala:31:21: value foreach is not a member of java.util.stream.Stream[String]

[error]       content.lines.foreach(executeTextCommand(session))

[error]                     ^

[error] /home/travis/.sbt/1.0/staging/05cb89211ea66aea052a/gatling-imap/src/main/scala-2.12/com/linagora/gatling/imap/protocol/command/AppendHandler.scala:31:47: missing argument list for method executeTextCommand in class AppendHandler

[error] Unapplied methods are only converted to functions when a function type is expected.

[error] You can make this conversion explicit by writing `executeTextCommand _` or `executeTextCommand(_)(_)` instead of `executeTextCommand`.

[error]       content.lines.foreach(executeTextCommand(session))

[error]                                               ^

[error] /home/travis/.sbt/1.0/staging/05cb89211ea66aea052a/gatling-imap/src/main/scala-2.12/com/linagora/gatling/imap/protocol/command/AppendHandler.scala:41:51: value length is not a member of java.util.stream.Stream[String]

[error]       val length = content.length + content.lines.length - 1

[error]                                                   ^

[error] three errors found

[error] (ProjectRef(uri("git://github.com/linagora/gatling-imap.git"), "gatling-imap") / Compile / compileIncremental) Compilation failed

[error] Total time: 56 s, completed Oct 15, 2019, 3:42:07 AM

restoring stty: 500:5:bf:8a3b:3:1c:7f:15:4:0:1:0:11:13:1a:0:12:f:17:16:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0

The command "sbt compile" exited with 1.
```