### PR TITLE
Jdk11 compatibility

### DIFF
--- a/src/main/scala-2.12/com/linagora/gatling/imap/protocol/ImapSessions.scala
+++ b/src/main/scala-2.12/com/linagora/gatling/imap/protocol/ImapSessions.scala
@@ -139,6 +139,8 @@ private class ImapSession(client: IMAPClient, protocol: ImapProtocol) extends Ba
     case msg@Command.Disconnect(userId) =>
       session.disconnect()
       context.become(disconnecting(sender()))
+    case message =>
+      logger.error(s"connected - got unexpected message $message")
 
   }
 

--- a/src/main/scala-2.12/com/linagora/gatling/imap/protocol/command/AppendHandler.scala
+++ b/src/main/scala-2.12/com/linagora/gatling/imap/protocol/command/AppendHandler.scala
@@ -28,7 +28,7 @@ class AppendHandler(session: IMAPSession, tag: Tag) extends BaseActor {
 
   private[this] def doOnMessageForContent(content: String): (IMAPSession, IMAPResponse) => Unit = (session, response) => {
     if (response.isContinuation) {
-      content.lines.foreach(executeTextCommand(session))
+      content.linesIterator.foreach(executeTextCommand(session))
     }
   }
 
@@ -38,19 +38,17 @@ class AppendHandler(session: IMAPSession, tag: Tag) extends BaseActor {
 
       val listener = new RespondToActorIMAPCommandListener(self, userId, Response.Appended, doOnMessage = doOnMessageForContent(content))(logger)
       val flagsAsString = flags.map(_.mkString("(", " ", ")")).getOrElse("()")
-      val length = content.length + content.lines.length - 1
+      val length = content.length + content.linesIterator.length - 1
       logger.debug(s"APPEND receive from sender ${sender.path} on ${self.path}")
       context.become(waitCallback(sender()))
       Try(session.executeAppendCommand(tag.string, mailbox, flagsAsString, length.toString, listener)) match {
         case Success(futureResult) =>
-          futureResult.addListener(new IMAPChannelFutureListener {
-            override def operationComplete(future: IMAPChannelFuture): Unit = {
-              logger.debug(s"AppendHandler command completed, success : ${future.isSuccess}")
-              if (!future.isSuccess) {
-                logger.error("AppendHandler command failed", future.cause())
-              }
-
+          futureResult.addListener((future: IMAPChannelFuture) => {
+            logger.debug(s"AppendHandler command completed, success : ${future.isSuccess}")
+            if (!future.isSuccess) {
+              logger.error("AppendHandler command failed", future.cause())
             }
+
           })
         case Failure(e) =>
           logger.error("ERROR when executing APPEND COMMAND", e)


### PR DESCRIPTION
replace call to `lines` method on strings with `linesIterator` as the first one conflict with the lines method returning a `Stream` added by the JDK11