### PR TITLE
Add a Jenkins timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,11 @@
 pipeline {
     agent any
+
+    options {
+        // Configure an overall timeout for the build.
+        timeout(time: 1, unit: 'HOURS')
+    }
+
     stages {
         stage('Compile') {
             steps {


### PR DESCRIPTION
This could prevent a non-stopping build in the future.